### PR TITLE
improve accessibility | contrast of charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This MicroHack will focus on enabling the participants to write Kusto queries to
 This Microhack will focus on enabling the participants to create Materialized Views, Functions, and use advanced operators to explore and analyze the data.
 
 ---
-Earn a digital badge! In order to receive the ADX microhack digital badge, you will need to complete the challenges marked with 🎓 in each Microhack. Please submit the KQL queries/commands using the answer sheets found at the beginning of each microhack. </br></br>
+Earn a digital badge! In order to receive the ADX microhack digital badge, you will need to complete the challenges marked with ✅ in each Microhack. Please submit the KQL queries/commands using the answer sheets found at the beginning of each microhack. </br></br>
 ---
 <p align="center"><img src="/assets/images/Badge-microhack-2stars.png" width="300"></p>
 


### PR DESCRIPTION
Improving accessibility of Azure Data Explorer Microhack by choosing a charm (in questions that require an answer) that has better contrast when using a darker theme in GitHub.
 
Replaces issue #19, same change approved in [improve accessibility | contrast of charm #15](https://github.com/Azure/ADX-in-a-Day/issues/15) where hfleitas has validated change with accessibility SME.